### PR TITLE
Corregido el error de autenticación.

### DIFF
--- a/myproject/apps/myapp/forms/customForms.py
+++ b/myproject/apps/myapp/forms/customForms.py
@@ -5,18 +5,18 @@ class LoginForm(forms.Form):
     email = forms.EmailField(max_length=100, required=True)
     password = forms.CharField( widget= forms.PasswordInput, required=True)
 
-    def login(self):
-        email = self.cleaned_data.get('email') 
-        password = self.cleaned_data.get('password')
-        user = User.authenticate(email, password) 
-        if user == None:
-            print("==== Failed Authentication ====") 
-            raise forms.ValidationError("Constraseña Incorrecta")    
-        return user 
+    # def login(self):
+    #     email = self.cleaned_data.get('email') 
+    #     password = self.cleaned_data.get('password')
+    #     user = User.authenticate(email, password) 
+    #     if user == None:
+    #         print("==== Failed Authentication ====") 
+    #         raise forms.ValidationError("Constraseña Incorrecta")    
+    #     return user 
 
     def clean(self):
-        cleaned_data = super().clean()
-        email = cleaned_data.get('email')
-        user_exist = User.user_exists(email)
-        if not user_exist:
-            raise forms.ValidationError("Usuario no Existe")    
+        email = self.cleaned_data['email']
+        password = self.cleaned_data['password']
+        user = User.authenticate(email, password)
+        if user == None:
+            raise forms.ValidationError("Datos no válidos")

--- a/myproject/apps/myapp/views.py
+++ b/myproject/apps/myapp/views.py
@@ -17,10 +17,9 @@ def login(request):
     formLogin = LoginForm(request.POST or None)
     if request.method == "POST":
         if formLogin.is_valid():
-            logged_user = formLogin.login()
-            if logged_user != None:
-                request.session['logged_username'] = logged_user.name
-                return redirect('/home')      
+            # if logged_user != None:
+            #     request.session['logged_username'] = logged_user.name
+            return redirect('/home')      
     return render(request, 'login.html', {'formLogin':formLogin})
 
 def register(request):


### PR DESCRIPTION
Cuando se crean mensajes ValidationError se deben utilizar los métodos clean de los formularios para mostrar los errores al usuario. De esta forma se elimina el tener que validar varias veces la información del usuario, es decir, si el email o la contraseña no coinciden simplemente se muestra el mismo mensaje de error.

Recomendación: Puedes utilizar la función user_exist para que retorne el usuario o None en lugar de un bool, y con esto puedes obtener el usuario para determinar si muestras un mensaje de error o utilizas el usuario para continuar en tu aplicación.